### PR TITLE
Adds support for making vcpkg conditional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,10 +17,14 @@ include(${_project_options_SOURCE_DIR}/Index.cmake)
 
 include("./Features.cmake")
 
-# Install vcpkg dependencies — must come before project()
-run_vcpkg(
-  VCPKG_URL "https://github.com/microsoft/vcpkg.git"
-  VCPKG_REV "50c0cb48a0cf2f6fc5c7b2c0d2bafbe26d0a7ca2")
+option(ENABLE_VCPKG "Use vcpkg to install dependencies" ${WIN32})
+
+# Install vcpkg dependencies when enabled — must come before project()
+if(ENABLE_VCPKG)
+  run_vcpkg(
+    VCPKG_URL "https://github.com/microsoft/vcpkg.git"
+    VCPKG_REV "50c0cb48a0cf2f6fc5c7b2c0d2bafbe26d0a7ca2")
+endif()
 
 project(
   gpu_driver_learning
@@ -29,9 +33,10 @@ project(
   HOMEPAGE_URL "https://github.com/AlphaPixel/gpu-driver-learning"
   LANGUAGES CXX C)
 
+include("./cmake/Dependencies.cmake")
+
 if(FEATURE_TESTS)
   enable_testing()
-  find_package(Catch2 REQUIRED)
   add_library(catch2_test_common INTERFACE)
   target_find_dependencies(catch2_test_common INTERFACE_CONFIG Catch2)
   target_link_libraries(catch2_test_common INTERFACE Catch2::Catch2 Catch2::Catch2WithMain)

--- a/apps/gpu_app_mock_dumbfb/CMakeLists.txt
+++ b/apps/gpu_app_mock_dumbfb/CMakeLists.txt
@@ -9,10 +9,7 @@ target_link_libraries(gpu_app_mock_dumbfb_lib INTERFACE gpu_project_options gpu_
 # Includes
 target_include_interface_directories(gpu_app_mock_dumbfb_lib include)
 
-# Find dependencies:
-target_find_dependencies(gpu_app_mock_dumbfb_lib INTERFACE_CONFIG fmt)
-set_target_properties(fmt::fmt PROPERTIES INTERFACE_COMPILE_OPTIONS
-                                          $<$<AND:$<COMPILE_LANGUAGE:CXX>,$<CXX_COMPILER_ID:MSVC>>:/utf-8>)
+target_compile_options(gpu_app_mock_dumbfb_lib INTERFACE $<$<AND:$<COMPILE_LANGUAGE:CXX>,$<CXX_COMPILER_ID:MSVC>>:/utf-8>)
 
 # Link dependencies:
 target_link_system_libraries(gpu_app_mock_dumbfb_lib INTERFACE fmt::fmt)
@@ -43,11 +40,6 @@ if(WIN32)
         COMMAND_EXPAND_LISTS
     )
 endif()
-
-# Find dependencies:
-target_find_dependencies(gpu_app_mock_dumbfb PRIVATE_CONFIG fmt)
-set_target_properties(fmt::fmt PROPERTIES INTERFACE_COMPILE_OPTIONS
-                                          $<$<AND:$<COMPILE_LANGUAGE:CXX>,$<CXX_COMPILER_ID:MSVC>>:/utf-8>)
 # Link dependencies
 target_link_system_libraries(gpu_app_mock_dumbfb PRIVATE fmt::fmt)
 

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -1,0 +1,36 @@
+include(FetchContent)
+
+find_package(fmt 11.0.2 CONFIG QUIET)
+if(NOT fmt_FOUND)
+  FetchContent_Declare(
+    fmt
+    URL https://github.com/fmtlib/fmt/archive/refs/tags/11.0.2.zip)
+  FetchContent_MakeAvailable(fmt)
+endif()
+
+if(FEATURE_TESTS)
+  find_package(Catch2 3.8.0 CONFIG QUIET)
+  if(NOT Catch2_FOUND)
+    FetchContent_Declare(
+      Catch2
+      URL https://github.com/catchorg/Catch2/archive/refs/tags/v3.8.0.zip)
+    FetchContent_MakeAvailable(Catch2)
+  endif()
+
+  if(DEFINED catch2_SOURCE_DIR AND EXISTS "${catch2_SOURCE_DIR}/extras/Catch.cmake")
+    list(APPEND CMAKE_MODULE_PATH "${catch2_SOURCE_DIR}/extras")
+  elseif(DEFINED Catch2_DIR)
+    find_file(
+      CATCH2_CMAKE_MODULE
+      Catch.cmake
+      PATHS
+        "${Catch2_DIR}"
+        "${Catch2_DIR}/../extras"
+        "${Catch2_DIR}/../../extras"
+      NO_DEFAULT_PATH)
+    if(CATCH2_CMAKE_MODULE)
+      get_filename_component(CATCH2_CMAKE_MODULE_DIR "${CATCH2_CMAKE_MODULE}" DIRECTORY)
+      list(APPEND CMAKE_MODULE_PATH "${CATCH2_CMAKE_MODULE_DIR}")
+    endif()
+  endif()
+endif()

--- a/libs/gpu_lib_mock_dumbfb/CMakeLists.txt
+++ b/libs/gpu_lib_mock_dumbfb/CMakeLists.txt
@@ -17,6 +17,8 @@ target_link_libraries(gpu_lib_mock_dumbfb
         gpu_project_warnings
 )
 
+target_compile_options(gpu_lib_mock_dumbfb PRIVATE $<$<AND:$<COMPILE_LANGUAGE:CXX>,$<CXX_COMPILER_ID:MSVC>>:/utf-8>)
+
 # Public C++ headers  →  #include <pixelgpu/...>
 target_include_directories(gpu_lib_mock_dumbfb
     PUBLIC


### PR DESCRIPTION
This patch uses a check against whether or not $WIN32 is set in CMake to determine when `vcpkg` should be used. When set to `FALSE`, Catch2/libfmt are pulled via `FetchContent`.