### PR TITLE
Prepare gpu_app_mock_dumbfb.cpp for Lesson 2

### DIFF
--- a/apps/gpu_app_mock_dumbfb/src/gpu_app_mock_dumbfb.cpp
+++ b/apps/gpu_app_mock_dumbfb/src/gpu_app_mock_dumbfb.cpp
@@ -28,29 +28,29 @@
 // ---------------------------------------------------------------------------
 // XBGR8888 pixel packing helper (you can rewrite this yourself from scratch)
 // ---------------------------------------------------------------------------
-//static inline uint32_t xbgr(uint8_t r, uint8_t g, uint8_t b) noexcept {
-//    // Byte layout in memory: [B][G][R][X]
-//    // As a uint32_t on little-endian: X=byte3, R=byte2, G=byte1, B=byte0
-//    return (static_cast<uint32_t>(0xFF) << 24)  // X = 0xFF (unused)
-//         | (static_cast<uint32_t>(r)    << 16)
-//         | (static_cast<uint32_t>(g)    <<  8)
-//         | (static_cast<uint32_t>(b));
-//}
+static inline uint32_t xbgr(uint8_t r, uint8_t g, uint8_t b) noexcept {
+    // Byte layout in memory: [B][G][R][X]
+    // As a uint32_t on little-endian: X=byte3, R=byte2, G=byte1, B=byte0
+    return (static_cast<uint32_t>(0xFF) << 24)  // X = 0xFF (unused)
+         | (static_cast<uint32_t>(r)    << 16)
+         | (static_cast<uint32_t>(g)    <<  8)
+         | (static_cast<uint32_t>(b));
+}
 
 // ---------------------------------------------------------------------------
 // Plot a single pixel into the framebuffer (no bounds check — caller beware!)
 // ---------------------------------------------------------------------------
-//static inline void plot(uint32_t* fb, uint32_t stride_px,
-//                        uint32_t x, uint32_t y, uint32_t color) noexcept {
-//    fb[y * stride_px + x] = color;
-//}
+static inline void plot(uint32_t* fb, uint32_t stride_px,
+                        uint32_t x, uint32_t y, uint32_t color) noexcept {
+    fb[y * stride_px + x] = color;
+}
 
 // ---------------------------------------------------------------------------
 // Fill the entire framebuffer with one colour (can re-implement for practice)
 // ---------------------------------------------------------------------------
-//static void fill(uint32_t* fb, uint32_t npixels, uint32_t color) noexcept {
-//    for (uint32_t i = 0; i < npixels; ++i)
-//        fb[i] = color;
+static void fill(uint32_t* fb, uint32_t npixels, uint32_t color) noexcept {
+    for (uint32_t i = 0; i < npixels; ++i)
+        fb[i] = color;
 //}
 
 


### PR DESCRIPTION
## Summary

- Uncomments the `xbgr()`, `plot()`, and `fill()` helper functions in `apps/gpu_app_mock_dumbfb/src/gpu_app_mock_dumbfb.cpp`
- These helpers were previously commented out in the student skeleton; activating them makes the skeleton ready for Lesson 2 students to build on

Closes #13

## Test plan

- [ ] Verify `gpu_app_mock_dumbfb` still builds cleanly after the change
- [ ] Confirm the helper functions are accessible for use in the Lesson 2 drawing challenges

🤖 Generated with [Claude Code](https://claude.com/claude-code)